### PR TITLE
Update URLs and headers

### DIFF
--- a/ESSAppStoreConnectAPI/ESSAppStoreConnectAPI.m
+++ b/ESSAppStoreConnectAPI/ESSAppStoreConnectAPI.m
@@ -155,7 +155,7 @@ static ESSAppStoreConnectAPI *_shAPI = nil;
 	}
 	
 	//first, retrieve authServiceKey / Apple Widget Key
-	NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://olympus.itunes.apple.com/v1/app/config?hostname=itunesconnect.apple.com"]];
+	NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://appstoreconnect.apple.com/olympus/v1/app/config?hostname=itunesconnect.apple.com"]];
 	NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:req
 																 completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
 																	 dispatch_async(dispatch_get_main_queue(), ^{
@@ -799,7 +799,7 @@ static ESSAppStoreConnectAPI *_shAPI = nil;
 {
 	NSAssert(completionHandler != nil && self.authServiceKey.length != 0, @"completionHandler, identificationCookie and authServiceKey may not be nil");
 	
-	NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://olympus.itunes.apple.com/v1/session"]];
+	NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://appstoreconnect.apple.com/olympus/v1/session"]];
 	req.HTTPShouldHandleCookies = YES;
 	[self _updateHeadersForRequest:req additionalFields:nil];
 	NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:req completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {

--- a/ESSAppStoreConnectAPI/ESSAppStoreConnectAPI.m
+++ b/ESSAppStoreConnectAPI/ESSAppStoreConnectAPI.m
@@ -733,7 +733,8 @@ static ESSAppStoreConnectAPI *_shAPI = nil;
 	[req setValue:@"application/json, text/javascript" forHTTPHeaderField:@"Accept"];
 	[req setValue:@"keep-alive" forHTTPHeaderField:@"Connection"];
 	[req setValue:@"PromoCodes for Mac and iOS by Eternal Storms Software" forHTTPHeaderField:@"User-Agent"];
-	
+	[req setValue:@"itc" forHTTPHeaderField:@"X-Csrf-Itc"];
+
 	if (additionalFields.allKeys.count != 0)
 	{
 		for (NSString *key in additionalFields.allKeys)


### PR DESCRIPTION
Thanks a lot for building this!

This PR includes 2 changes to make it work again:

- change the URL of the Olympus service
- adds a required `X-Csrf-Itc` header, without this the response for creating codes is a 404